### PR TITLE
Fix test broken in Makie 0.21

### DIFF
--- a/test/ribbon/render.jl
+++ b/test/ribbon/render.jl
@@ -5,5 +5,4 @@ import GLMakie
     @test ribbon(protein) isa GLMakie.Scene
     scene = ribbon(protein; camcontrols=(; lookat=Vec3f(30, 0, 60), eyeposition=Vec3f(160, -75, 0), upvector=Vec3f(0, 0, 1)))
     @test scene.camera.eyeposition[] == Vec3f(160, -75, 0)
-    @test scene.camera.lookat[] == Vec3f(30, 0, 60)
 end


### PR DESCRIPTION
PR #21 collided with #22, in that `lookat` was removed as a field in
Makie 0.21.