### PR TITLE
[compat] Require Backboner 0.9.7

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,7 +12,7 @@ Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
 
 [compat]
 AssigningSecondaryStructure = "0.3"
-Backboner = "0.9"
+Backboner = "0.9.7"
 Dierckx = "0.5"
 LinearAlgebra = "1"
 Makie = "0.21"


### PR DESCRIPTION
`Protein.assign_oxygens!` first became available in Backboner 0.9.7 and is required for this package. Noticed because I was using a `dev` copy of ProtPlot and a `git pull` brought in the latest changes without updating Backboner.