### PR TITLE
Support `BioStructures.Chain` with `ramachandran`

### DIFF
--- a/src/misc/ramachandran.jl
+++ b/src/misc/ramachandran.jl
@@ -32,3 +32,5 @@ function Makie.convert_arguments(::Type{<:Ramachandran}, chains::AbstractVector{
 end
 
 Makie.convert_arguments(T::Type{<:Ramachandran}, path::AbstractString) = Makie.convert_arguments(T, read(path, ProteinStructure))
+Makie.convert_arguments(T::Type{<:Ramachandran}, chain::BioStructures.Chain) = Makie.convert_arguments(T, ProteinChain(chain))
+Makie.convert_arguments(T::Type{<:Ramachandran}, structure::BioStructures.MolecularStructure) = Makie.convert_arguments(T, ProteinStructure(structure))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -23,6 +23,7 @@ import BioStructures
     @test atomplot(Frames(pdb"1ASS"A)) isa Makie.FigureAxisPlot
 
     @test ramachandran(pdb"1ASS") isa Makie.FigureAxisPlot
+    @test ramachandran(pdb"1ASS"A) isa Makie.FigureAxisPlot
 
     mktempdir() do dir
         BioStructures.downloadpdb("1M4X"; dir)


### PR DESCRIPTION
Getting a new release of ProteinChains would also be great! `ProteinChain(chain::BioStructures.Chain)` is available in the development version but not yet released.